### PR TITLE
Feat: Add download button config similar to print config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@iamjariwala/react-doc-viewer",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iamjariwala/react-doc-viewer",
-      "version": "1.7.1",
+      "version": "1.8.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "docx-preview-sync": "^0.4.20",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -48,3 +48,37 @@ test("renders doc viewer with initialActiveDocument prop", () => {
   expect(proxyRenderer).toBeDefined();
   expect(proxyRenderer.querySelector("img")).toBeDefined();
 });
+
+test("hides download button when enableDownload is false", () => {
+  const docs = [{ uri: "", fileType: "application/postscript" }];
+  render(
+    <DocViewer
+      documents={docs}
+      config={{ download: { enableDownload: false } }}
+    />,
+  );
+
+  expect(screen.getByTestId("react-doc-viewer")).toBeDefined();
+  expect(screen.queryByText("Download file")).not.toBeInTheDocument();
+});
+
+test("shows download button by default when enableDownload is not set", () => {
+  const docs = [{ uri: "", fileType: "application/postscript" }];
+  render(<DocViewer documents={docs} />);
+
+  expect(screen.getByTestId("react-doc-viewer")).toBeDefined();
+  expect(screen.getByText("Download file")).toBeInTheDocument();
+});
+
+test("shows download button when enableDownload is true", () => {
+  const docs = [{ uri: "", fileType: "application/postscript" }];
+  render(
+    <DocViewer
+      documents={docs}
+      config={{ download: { enableDownload: true } }}
+    />,
+  );
+
+  expect(screen.getByTestId("react-doc-viewer")).toBeDefined();
+  expect(screen.getByText("Download file")).toBeInTheDocument();
+});

--- a/src/components/CommonToolbar.tsx
+++ b/src/components/CommonToolbar.tsx
@@ -149,17 +149,36 @@ export const CommonToolbar: FC<CommonToolbarProps> = ({
   onPageChange,
 }) => {
   const { state } = useContext(DocViewerContext);
-  const { currentDocument } = state;
+  const { currentDocument, config } = state;
   const [pageInput, setPageInput] = useState(String(currentPage));
+  const enableDownload = config?.download?.enableDownload !== false;
+  const enablePrint = config?.print?.enablePrint !== false;
 
   const handleDownload = useCallback(() => {
     if (!currentDocument) return;
-    const url =
-      (currentDocument.fileData as string) || currentDocument.uri;
+
+    const fileData = currentDocument.fileData;
     const name =
       currentDocument.fileName ||
       currentDocument.uri?.split("/").pop() ||
       "download";
+
+    // Handle ArrayBuffer fileData
+    if (fileData instanceof ArrayBuffer) {
+      const mimeType = currentDocument.fileType || "application/octet-stream";
+      const blob = new Blob([fileData], { type: mimeType });
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = blobUrl;
+      a.download = name;
+      a.click();
+      URL.revokeObjectURL(blobUrl);
+      return;
+    }
+
+    // Handle string (data URL or regular URL) or fall back to URI
+    const url =
+      (typeof fileData === "string" ? fileData : null) || currentDocument.uri;
     if (!url) return;
 
     fetch(url)
@@ -211,7 +230,10 @@ export const CommonToolbar: FC<CommonToolbarProps> = ({
 
   const zoomPercent = Math.round(zoomLevel * 100);
 
-  if (currentPage !== parseInt(pageInput, 10) && document.activeElement?.className !== "rdv-toolbar-page-input") {
+  if (
+    currentPage !== parseInt(pageInput, 10) &&
+    document.activeElement?.className !== "rdv-toolbar-page-input"
+  ) {
     setPageInput(String(currentPage));
   }
 
@@ -253,24 +275,32 @@ export const CommonToolbar: FC<CommonToolbarProps> = ({
           </>
         )}
 
-        <div className="rdv-toolbar-group">
-          <button
-            className="rdv-toolbar-btn"
-            title="Download"
-            onMouseDown={handleDownload}
-          >
-            <DownloadIcon size="16" />
-          </button>
-          <button
-            className="rdv-toolbar-btn"
-            title="Print"
-            onMouseDown={handlePrint}
-          >
-            <PrintIcon size="16" />
-          </button>
-        </div>
+        {(enableDownload || enablePrint) && (
+          <>
+            <div className="rdv-toolbar-group">
+              {enableDownload && (
+                <button
+                  className="rdv-toolbar-btn"
+                  title="Download"
+                  onMouseDown={handleDownload}
+                >
+                  <DownloadIcon size="16" />
+                </button>
+              )}
+              {enablePrint && (
+                <button
+                  className="rdv-toolbar-btn"
+                  title="Print"
+                  onMouseDown={handlePrint}
+                >
+                  <PrintIcon size="16" />
+                </button>
+              )}
+            </div>
 
-        <div className="rdv-toolbar-divider" />
+            <div className="rdv-toolbar-divider" />
+          </>
+        )}
 
         <div className="rdv-toolbar-group">
           <button

--- a/src/components/ProxyRenderer.tsx
+++ b/src/components/ProxyRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC, useCallback, useState, useRef, useEffect } from "react";
+import { FC, useCallback, useState, useRef, useEffect, RefObject } from "react";
 import { setRendererRect } from "../store/actions";
 import { DocRenderer, IConfig, IDocument } from "../models";
 import { getFileName } from "../utils/getFileName";
@@ -17,10 +17,7 @@ const ZOOM_STEP = 0.1;
 const MIN_ZOOM = 0.25;
 const MAX_ZOOM = 3;
 
-const PAGE_SELECTORS = [
-  "section.rdv-docx",
-  ".react-pdf__Page",
-].join(", ");
+const PAGE_SELECTORS = ["section.rdv-docx", ".react-pdf__Page"].join(", ");
 
 function detectPages(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(PAGE_SELECTORS));
@@ -41,7 +38,7 @@ type ContentsProps = {
   numPages: number;
   currentPage: number;
   onPageChange: (page: number) => void;
-  contentRef: React.RefObject<HTMLDivElement>;
+  contentRef: RefObject<HTMLDivElement>;
   t: (
     key:
       | "noRendererMessage"
@@ -88,7 +85,11 @@ const Contents: React.FC<ContentsProps> = ({
 
     return (
       <LoadingTimeout>
-        <div id="loading-renderer" data-testid="loading-renderer" className="rdv-loading-container">
+        <div
+          id="loading-renderer"
+          data-testid="loading-renderer"
+          className="rdv-loading-container"
+        >
           <div className="rdv-loading-icon">
             <LoadingIcon color="#444" size={40} />
           </div>
@@ -121,7 +122,8 @@ const Contents: React.FC<ContentsProps> = ({
             className="rdv-common-content-wrapper"
             style={{
               transformOrigin: "top center",
-              transform: zoomLevel === DEFAULT_ZOOM ? undefined : `scale(${zoomLevel})`,
+              transform:
+                zoomLevel === DEFAULT_ZOOM ? undefined : `scale(${zoomLevel})`,
             }}
           >
             <CurrentRenderer mainState={state} />
@@ -138,19 +140,22 @@ const Contents: React.FC<ContentsProps> = ({
         );
       }
 
+      const enableDownload = config?.download?.enableDownload !== false;
       return (
         <div id="no-renderer" data-testid="no-renderer">
           {t("noRendererMessage", {
             fileType: currentDocument?.fileType ?? "",
           })}
-          <LinkButton
-            id="no-renderer-download"
-            className="rdv-download-btn"
-            href={currentDocument?.uri}
-            download={currentDocument?.uri}
-          >
-            {t("downloadButtonLabel")}
-          </LinkButton>
+          {enableDownload && (
+            <LinkButton
+              id="no-renderer-download"
+              className="rdv-download-btn"
+              href={currentDocument?.uri}
+              download={currentDocument?.uri}
+            >
+              {t("downloadButtonLabel")}
+            </LinkButton>
+          )}
         </div>
       );
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -8,7 +8,10 @@ export interface IDragDropConfig {
   maxFileSize?: number;
   dropBehavior?: "append" | "replace";
   onDrop?: (files: File[]) => void;
-  onDropRejected?: (files: File[], reason: "file-type" | "file-size" | "unknown") => void;
+  onDropRejected?: (
+    files: File[],
+    reason: "file-type" | "file-size" | "unknown",
+  ) => void;
 }
 
 export interface IThumbnailConfig {
@@ -55,6 +58,10 @@ export interface ICommentData {
 
 export interface IPrintConfig {
   enablePrint?: boolean;
+}
+
+export interface IDownloadConfig {
+  enableDownload?: boolean;
 }
 
 export interface IFullscreenConfig {
@@ -138,6 +145,7 @@ export interface IConfig {
   annotations?: IAnnotationConfig;
   themeMode?: "light" | "dark" | "auto";
   print?: IPrintConfig;
+  download?: IDownloadConfig;
   fullscreen?: IFullscreenConfig;
   loadingProgress?: ILoadingProgressConfig;
   watermark?: IWatermarkConfig;
@@ -199,7 +207,6 @@ export interface ITheme {
   textTertiary?: string;
   disableThemeScrollbar?: boolean;
 }
-
 
 export interface IDocument {
   uri: string;

--- a/src/renderers/docx/index.tsx
+++ b/src/renderers/docx/index.tsx
@@ -27,6 +27,7 @@ const DocxRenderer: DocRenderer = ({
   const uri = currentDocument?.uri ?? "";
   const officeOnlineEnabled = config?.docx?.useOfficeOnlineViewer === true;
   const useOfficeViewer = officeOnlineEnabled && isPublicUrl(uri);
+  const enableDownload = config?.download?.enableDownload !== false;
 
   useEffect(() => {
     if (useOfficeViewer) {
@@ -116,32 +117,34 @@ const DocxRenderer: DocRenderer = ({
           <div className="rdv-msdoc-file-type">
             Unable to preview this document
           </div>
-          <a
-            className="rdv-msdoc-download-link"
-            href={currentDocument.uri}
-            download={fileName}
-            onClick={(e) => {
-              e.preventDefault();
-              fetch(currentDocument.uri)
-                .then((res) => res.blob())
-                .then((blob) => {
-                  const blobUrl = URL.createObjectURL(blob);
-                  const a = document.createElement("a");
-                  a.href = blobUrl;
-                  a.download = fileName;
-                  a.click();
-                  URL.revokeObjectURL(blobUrl);
-                })
-                .catch(() => {
-                  const a = document.createElement("a");
-                  a.href = currentDocument.uri;
-                  a.download = fileName;
-                  a.click();
-                });
-            }}
-          >
-            Download File
-          </a>
+          {enableDownload && (
+            <a
+              className="rdv-msdoc-download-link"
+              href={currentDocument.uri}
+              download={fileName}
+              onClick={(e) => {
+                e.preventDefault();
+                fetch(currentDocument.uri)
+                  .then((res) => res.blob())
+                  .then((blob) => {
+                    const blobUrl = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = blobUrl;
+                    a.download = fileName;
+                    a.click();
+                    URL.revokeObjectURL(blobUrl);
+                  })
+                  .catch(() => {
+                    const a = document.createElement("a");
+                    a.href = currentDocument.uri;
+                    a.download = fileName;
+                    a.click();
+                  });
+              }}
+            >
+              Download File
+            </a>
+          )}
         </div>
       </div>
     );

--- a/src/renderers/msdoc/index.tsx
+++ b/src/renderers/msdoc/index.tsx
@@ -29,19 +29,21 @@ const IFRAME_SUPPORTED_TYPES = new Set([
 const isRemoteUrl = (uri: string): boolean =>
   uri.startsWith("http://") || uri.startsWith("https://");
 
-const MSDocRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
+const MSDocRenderer: DocRenderer = ({
+  mainState: { currentDocument, config },
+}) => {
   const [iframeError, setIframeError] = useState(false);
 
   if (!currentDocument) return null;
 
+  const enableDownload = config?.download?.enableDownload !== false;
   const fileName =
     currentDocument.fileName ||
     currentDocument.uri.split("/").pop() ||
     "document";
   const fileType = currentDocument.fileType || "";
   const label =
-    FILE_TYPE_LABELS[fileType] ||
-    `Office Document (.${fileType || "unknown"})`;
+    FILE_TYPE_LABELS[fileType] || `Office Document (.${fileType || "unknown"})`;
 
   const canUseIframe =
     isRemoteUrl(currentDocument.uri) &&
@@ -87,33 +89,35 @@ const MSDocRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
         </div>
         <div className="rdv-msdoc-file-name">{fileName}</div>
         <div className="rdv-msdoc-file-type">{label}</div>
-        <a
-          className="rdv-msdoc-download-link"
-          href={currentDocument.uri}
-          download={fileName}
-          onClick={(e) => {
-            e.preventDefault();
-            const url = currentDocument.uri;
-            fetch(url)
-              .then((res) => res.blob())
-              .then((blob) => {
-                const blobUrl = URL.createObjectURL(blob);
-                const a = document.createElement("a");
-                a.href = blobUrl;
-                a.download = fileName;
-                a.click();
-                URL.revokeObjectURL(blobUrl);
-              })
-              .catch(() => {
-                const a = document.createElement("a");
-                a.href = url;
-                a.download = fileName;
-                a.click();
-              });
-          }}
-        >
-          Download File
-        </a>
+        {enableDownload && (
+          <a
+            className="rdv-msdoc-download-link"
+            href={currentDocument.uri}
+            download={fileName}
+            onClick={(e) => {
+              e.preventDefault();
+              const url = currentDocument.uri;
+              fetch(url)
+                .then((res) => res.blob())
+                .then((blob) => {
+                  const blobUrl = URL.createObjectURL(blob);
+                  const a = document.createElement("a");
+                  a.href = blobUrl;
+                  a.download = fileName;
+                  a.click();
+                  URL.revokeObjectURL(blobUrl);
+                })
+                .catch(() => {
+                  const a = document.createElement("a");
+                  a.href = url;
+                  a.download = fileName;
+                  a.click();
+                });
+            }}
+          >
+            Download File
+          </a>
+        )}
       </div>
     </div>
   );

--- a/src/renderers/pdf/components/PDFControls.tsx
+++ b/src/renderers/pdf/components/PDFControls.tsx
@@ -47,15 +47,41 @@ const PDFControls: FC<Props> = ({ containerRef }) => {
   const thumbnailConfig = mainState?.config?.thumbnail;
   const enableThumbnails = thumbnailConfig?.enableThumbnails ?? false;
   const enablePrint = mainState?.config?.print?.enablePrint ?? false;
-  const enableFullscreen = mainState?.config?.fullscreen?.enableFullscreen ?? false;
+  const enableDownload = mainState?.config?.download?.enableDownload !== false;
+  const enableFullscreen =
+    mainState?.config?.fullscreen?.enableFullscreen ?? false;
   const enableSearch = mainState?.config?.search?.enableSearch ?? false;
-  const enableBookmarks = mainState?.config?.bookmarks?.enableBookmarks ?? false;
+  const enableBookmarks =
+    mainState?.config?.bookmarks?.enableBookmarks ?? false;
   const zoomPercent = Math.round(zoomLevel * 100);
 
   const handleDownload = useCallback(() => {
-    const url = currentDocument?.fileData as string;
-    const name = currentDocument?.fileName || currentDocument?.uri || "download";
+    if (!currentDocument) return;
+
+    const fileData = currentDocument.fileData;
+    const name =
+      currentDocument.fileName ||
+      currentDocument.uri?.split("/").pop() ||
+      "download";
+
+    // Handle ArrayBuffer fileData
+    if (fileData instanceof ArrayBuffer) {
+      const mimeType = currentDocument.fileType || "application/pdf";
+      const blob = new Blob([fileData], { type: mimeType });
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = blobUrl;
+      a.download = name;
+      a.click();
+      URL.revokeObjectURL(blobUrl);
+      return;
+    }
+
+    // Handle string (data URL or regular URL) or fall back to URI
+    const url =
+      (typeof fileData === "string" ? fileData : null) || currentDocument.uri;
     if (!url) return;
+
     fetch(url)
       .then((res) => res.blob())
       .then((blob) => {
@@ -128,17 +154,19 @@ const PDFControls: FC<Props> = ({ containerRef }) => {
           </>
         )}
 
-        {currentDocument?.fileData && (
+        {currentDocument?.fileData && (enableDownload || enablePrint) && (
           <>
             <div className="rdv-toolbar-group">
-              <button
-                id="pdf-download"
-                className="rdv-toolbar-btn"
-                title={t("downloadButtonLabel")}
-                onMouseDown={handleDownload}
-              >
-                <DownloadPDFIcon size="16" />
-              </button>
+              {enableDownload && (
+                <button
+                  id="pdf-download"
+                  className="rdv-toolbar-btn"
+                  title={t("downloadButtonLabel")}
+                  onMouseDown={handleDownload}
+                >
+                  <DownloadPDFIcon size="16" />
+                </button>
+              )}
 
               {enablePrint && (
                 <button
@@ -222,9 +250,7 @@ const PDFControls: FC<Props> = ({ containerRef }) => {
 
           {enableBookmarks && <BookmarksToggle />}
 
-          {enableThumbnails && (
-            <ThumbnailToggle title="Toggle thumbnails" />
-          )}
+          {enableThumbnails && <ThumbnailToggle title="Toggle thumbnails" />}
 
           {numPages > 1 && (
             <button

--- a/src/stories/features.stories.tsx
+++ b/src/stories/features.stories.tsx
@@ -28,7 +28,8 @@ export const DragAndDrop = () => {
   return (
     <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
       <div style={{ padding: "10px", background: "#f0f0f0" }}>
-        <strong>Drag & Drop Demo</strong> - Drag PDF or image files onto the viewer below
+        <strong>Drag & Drop Demo</strong> - Drag PDF or image files onto the
+        viewer below
         {droppedFiles.length > 0 && (
           <div style={{ marginTop: "5px", fontSize: "12px" }}>
             Dropped: {droppedFiles.join(", ")}
@@ -80,7 +81,8 @@ export const Annotations = () => {
   return (
     <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
       <div style={{ padding: "10px", background: "#f0f0f0" }}>
-        <strong>Annotations Demo</strong> - Use the toolbar to highlight, draw, or add comments
+        <strong>Annotations Demo</strong> - Use the toolbar to highlight, draw,
+        or add comments
         <div style={{ marginTop: "5px", fontSize: "12px" }}>
           Annotations count: {annotations.length}
         </div>
@@ -112,7 +114,15 @@ export const PageJump = () => {
 
   return (
     <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-      <div style={{ padding: "10px", background: "#f0f0f0", display: "flex", gap: "10px", alignItems: "center" }}>
+      <div
+        style={{
+          padding: "10px",
+          background: "#f0f0f0",
+          display: "flex",
+          gap: "10px",
+          alignItems: "center",
+        }}
+      >
         <strong>Page Jump Demo</strong>
         <input
           type="number"
@@ -132,10 +142,16 @@ export const PageJump = () => {
         >
           Go to Page
         </button>
-        <button onClick={() => docViewerRef.current?.prev()} style={{ padding: "5px 15px" }}>
+        <button
+          onClick={() => docViewerRef.current?.prev()}
+          style={{ padding: "5px 15px" }}
+        >
           Prev Doc
         </button>
-        <button onClick={() => docViewerRef.current?.next()} style={{ padding: "5px 15px" }}>
+        <button
+          onClick={() => docViewerRef.current?.next()}
+          style={{ padding: "5px 15px" }}
+        >
           Next Doc
         </button>
       </div>
@@ -157,19 +173,39 @@ export const JumpToPageProp = () => {
 
   return (
     <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-      <div style={{ padding: "10px", background: "#f0f0f0", display: "flex", gap: "10px", alignItems: "center" }}>
+      <div
+        style={{
+          padding: "10px",
+          background: "#f0f0f0",
+          display: "flex",
+          gap: "10px",
+          alignItems: "center",
+        }}
+      >
         <strong>Jump To Page Prop Demo</strong>
         <span>Current Page: {currentPage}</span>
-        <button onClick={() => setCurrentPage(1)} style={{ padding: "5px 15px" }}>
+        <button
+          onClick={() => setCurrentPage(1)}
+          style={{ padding: "5px 15px" }}
+        >
           Page 1
         </button>
-        <button onClick={() => setCurrentPage(3)} style={{ padding: "5px 15px" }}>
+        <button
+          onClick={() => setCurrentPage(3)}
+          style={{ padding: "5px 15px" }}
+        >
           Page 3
         </button>
-        <button onClick={() => setCurrentPage(5)} style={{ padding: "5px 15px" }}>
+        <button
+          onClick={() => setCurrentPage(5)}
+          style={{ padding: "5px 15px" }}
+        >
           Page 5
         </button>
-        <button onClick={() => setCurrentPage(10)} style={{ padding: "5px 15px" }}>
+        <button
+          onClick={() => setCurrentPage(10)}
+          style={{ padding: "5px 15px" }}
+        >
           Page 10
         </button>
         <input
@@ -199,23 +235,40 @@ export const DarkMode = () => {
 
   return (
     <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-      <div style={{ padding: "10px", background: "#f0f0f0", display: "flex", gap: "10px", alignItems: "center" }}>
+      <div
+        style={{
+          padding: "10px",
+          background: "#f0f0f0",
+          display: "flex",
+          gap: "10px",
+          alignItems: "center",
+        }}
+      >
         <strong>Dark Mode Demo</strong>
         <button
           onClick={() => setMode("light")}
-          style={{ padding: "4px 12px", fontWeight: mode === "light" ? "bold" : "normal" }}
+          style={{
+            padding: "4px 12px",
+            fontWeight: mode === "light" ? "bold" : "normal",
+          }}
         >
           Light
         </button>
         <button
           onClick={() => setMode("dark")}
-          style={{ padding: "4px 12px", fontWeight: mode === "dark" ? "bold" : "normal" }}
+          style={{
+            padding: "4px 12px",
+            fontWeight: mode === "dark" ? "bold" : "normal",
+          }}
         >
           Dark
         </button>
         <button
           onClick={() => setMode("auto")}
-          style={{ padding: "4px 12px", fontWeight: mode === "auto" ? "bold" : "normal" }}
+          style={{
+            padding: "4px 12px",
+            fontWeight: mode === "auto" ? "bold" : "normal",
+          }}
         >
           Auto (System)
         </button>
@@ -240,6 +293,30 @@ export const PrintButton = () => (
       documents={[{ uri: pdfMultiplePagesFile }]}
       config={{
         print: { enablePrint: true },
+        pdfVerticalScrollByDefault: false,
+      }}
+    />
+  </div>
+);
+
+export const DownloadButton = () => (
+  <div style={{ height: "100vh" }}>
+    <DocViewer
+      documents={[{ uri: pdfMultiplePagesFile }]}
+      config={{
+        download: { enableDownload: false },
+        pdfVerticalScrollByDefault: false,
+      }}
+    />
+  </div>
+);
+
+export const DownloadButtonDisabled = () => (
+  <div style={{ height: "100vh" }}>
+    <DocViewer
+      documents={[{ uri: pdfMultiplePagesFile }]}
+      config={{
+        download: { enableDownload: false },
         pdfVerticalScrollByDefault: false,
       }}
     />
@@ -312,7 +389,16 @@ export const KeyboardShortcuts = () => (
   <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
     <div style={{ padding: "10px", background: "#f0f0f0" }}>
       <strong>Keyboard Shortcuts Demo</strong>
-      <div style={{ fontSize: "12px", color: "#666", marginTop: "4px", display: "flex", gap: "16px", flexWrap: "wrap" }}>
+      <div
+        style={{
+          fontSize: "12px",
+          color: "#666",
+          marginTop: "4px",
+          display: "flex",
+          gap: "16px",
+          flexWrap: "wrap",
+        }}
+      >
         <span>Arrow Left/Right: prev/next page</span>
         <span>Home/End: first/last page</span>
         <span>+/-: zoom in/out</span>
@@ -402,7 +488,8 @@ export const Bookmarks = () => (
     <div style={{ padding: "10px", background: "#f0f0f0" }}>
       <strong>Bookmarks / TOC Demo</strong>
       <span style={{ fontSize: "12px", color: "#666", marginLeft: "10px" }}>
-        Click the bookmark icon in the toolbar to show the table of contents sidebar
+        Click the bookmark icon in the toolbar to show the table of contents
+        sidebar
       </span>
     </div>
     <div style={{ flex: 1 }}>


### PR DESCRIPTION
Adds `config.download.enableDownload` in `IConfig` to enable or disable download button

## Screenshot
<img width="1566" height="881" alt="image" src="https://github.com/user-attachments/assets/1c34572d-f1a4-41e6-9df4-b0f1147cc8c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add config option to enable/disable downloads (enabled by default); toolbar and document UIs now hide download when disabled.
  * Improved download handling to support binary file data for direct client downloads.

* **Bug Fixes**
  * Toolbar now only shows download/print controls when those actions are enabled.

* **Tests**
  * Added UI tests validating download button visibility behavior.

* **Docs**
  * Added story examples demonstrating enabled/disabled download states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->